### PR TITLE
[Fix] Bug in example prediction for Arsenal vs. Manchester City

### DIFF
--- a/11SimulateMatches.py
+++ b/11SimulateMatches.py
@@ -39,7 +39,7 @@ away_team='Arsenal'
 home_score_rate=poisson_model.predict(pd.DataFrame(data={'team': home_team, 'opponent': away_team,
                                        'home':1},index=[1]))
 away_score_rate=poisson_model.predict(pd.DataFrame(data={'team': away_team, 'opponent': home_team,
-                                       'home':1},index=[1]))
+                                       'home':0},index=[1]))
 print(home_team + ' against ' + away_team + ' expect to score: ' + str(home_score_rate))
 print(away_team + ' against ' + home_team + ' expect to score: ' + str(away_score_rate))
 


### PR DESCRIPTION
Addresses a small bug in the example prediction of Arsenal (away team) v Man City (home team).

The Arsenal scoring rate (*away_score_rate*) is erroneously modelled as if Arsenal is also playing at home. This leads to the predicted goals being overstated.